### PR TITLE
remove support go 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: go
 go:
-  - 1.4
   - 1.5
   - 1.6
   - 1.7


### PR DESCRIPTION
the bellow error is `Time.AppendFormat` which was added to the language in Go 1.5.


```
# github.com/ugorji/go/codec
../../ugorji/go/codec/json.go:438: t.AppendFormat undefined (type time.Time has no field or method AppendFormat)
The command "go get github.com/ugorji/go/codec" failed and exited with 2 during .
```