### PR TITLE
Add options to ListJobs func.

### DIFF
--- a/api_job.go
+++ b/api_job.go
@@ -50,8 +50,8 @@ type ListJobsResultElements []ListJobsResultElement
 type ListJobsResult struct {
 	ListJobsResultElements ListJobsResultElements
 	Count                  int
-	From                   float64
-	To                     float64
+	From                   int
+	To                     int
 }
 
 var listJobsSchema = map[string]interface{}{
@@ -82,8 +82,8 @@ var listJobsSchema = map[string]interface{}{
 		},
 	},
 	"count": Optional{0, 0},
-	"to":    Optional{0., 0.},
-	"from":  Optional{0., 0.},
+	"to":    Optional{0, 0},
+	"from":  Optional{0, 0},
 }
 
 var jobStatusSchema = map[string]interface{}{
@@ -254,8 +254,8 @@ func (client *TDClient) ListJobsWithOptions(options *ListJobsOptions) (*ListJobs
 	}
 	listJobsResult.ListJobsResultElements = retval
 	listJobsResult.Count = js["count"].(int)
-	listJobsResult.From = js["from"].(float64)
-	listJobsResult.To = js["to"].(float64)
+	listJobsResult.From = js["from"].(int)
+	listJobsResult.To = js["to"].(int)
 	return &listJobsResult, nil
 }
 

--- a/api_job.go
+++ b/api_job.go
@@ -197,7 +197,7 @@ func (options *ListJobsOptions) WithTo(to int) *ListJobsOptions {
 
 func (options *ListJobsOptions) WithStatus(status string) *ListJobsOptions {
 	if status == "running" || status == "queued" || status == "success" || status == "error" {
-     	options.status = status
+		options.status = status
 	}
 	return options
 }

--- a/api_job.go
+++ b/api_job.go
@@ -50,8 +50,8 @@ type ListJobsResultElements []ListJobsResultElement
 type ListJobsResult struct {
 	ListJobsResultElements ListJobsResultElements
 	Count                  int
-	From                   string
-	To                     string
+	From                   float64
+	To                     float64
 }
 
 var listJobsSchema = map[string]interface{}{
@@ -82,8 +82,8 @@ var listJobsSchema = map[string]interface{}{
 		},
 	},
 	"count": Optional{0, 0},
-	"to":    Optional{"", "?"},
-	"from":  Optional{"", "?"},
+	"to":    Optional{0., 0.},
+	"from":  Optional{0., 0.},
 }
 
 var jobStatusSchema = map[string]interface{}{
@@ -179,8 +179,48 @@ var submitPartialDeleteJobSchema = map[string]interface{}{
 	"to":       0,
 }
 
-func (client *TDClient) ListJobs() (*ListJobsResult, error) {
-	resp, err := client.get("/v3/job/list", nil)
+type ListJobsOptions struct {
+	from   string
+	to     string
+	status string
+}
+
+func (options *ListJobsOptions) WithFrom(from int) *ListJobsOptions {
+	options.from = strconv.Itoa(from)
+	return options
+}
+
+func (options *ListJobsOptions) WithTo(to int) *ListJobsOptions {
+	options.to = strconv.Itoa(to)
+	return options
+}
+
+func (options *ListJobsOptions) WithStatus(status string) *ListJobsOptions {
+	if status == "running" || status == "queued" || status == "success" || status == "error" {
+     	options.status = status
+	}
+	return options
+}
+
+func (client *TDClient) ListJobsWithOptions(options *ListJobsOptions) (*ListJobsResult, error) {
+	requestUri := "/v3/job/list"
+	u, err := url.Parse(requestUri)
+	if err != nil {
+		return nil, err
+	}
+
+	queryString := u.Query()
+	if options.from != "" {
+		queryString.Set("from", options.from)
+	}
+	if options.to != "" {
+		queryString.Set("to", options.to)
+	}
+	if options.status != "" {
+		queryString.Set("status", options.status)
+	}
+
+	resp, err := client.get(requestUri, queryString)
 	if err != nil {
 		return nil, err
 	}
@@ -214,9 +254,13 @@ func (client *TDClient) ListJobs() (*ListJobsResult, error) {
 	}
 	listJobsResult.ListJobsResultElements = retval
 	listJobsResult.Count = js["count"].(int)
-	listJobsResult.From = js["from"].(string)
-	listJobsResult.To = js["to"].(string)
+	listJobsResult.From = js["from"].(float64)
+	listJobsResult.To = js["to"].(float64)
 	return &listJobsResult, nil
+}
+
+func (client *TDClient) ListJobs() (*ListJobsResult, error) {
+	return client.ListJobsWithOptions(&ListJobsOptions{})
 }
 
 func (client *TDClient) ShowJob(jobId string) (*ShowJobResult, error) {


### PR DESCRIPTION
Hi,

I had Treasure Data support taught us that the parameters `from`, `to` and `status` can be specified with the end point of Treasure Data API `/v3/job/list` (*).

By merging this pull request, it becomes possible to specify the parameters as shown below.

```go
func main() {
  client, _ := td_client.NewTDClient(td_client.Settings {
    ApiKey: <APIKEY>,
  })
  // use parametors
  options := &td_client.ListJobsOptions{}
  client.ListJobsWithOptions(options.WithFrom(0).WithTo(9).WithStatus("running"))
  // default
  client.ListJobs()
}
```

I made a new function ListJobsWithOptions in consideration of the backward compatibility of ListJobs, but I think that there is also an option that ListJobs takes arguments in strictness.
I would like to hear the thoughts of the contributors.

(*) Documents contains several parameters, including the old ones, but I understand that the currently available parameters are `from`, `to`, `status` and `slower_than`. The last one is written in the document to be avoided, so the implementation added in this pull request is not support this.
https://support.treasuredata.com/hc/en-us/articles/360001260527-REST-API#get-v3joblist
https://support.treasuredata.com/hc/en-us/articles/360020228934-Treasure-Data-Job-APIs