### PR TITLE
Update test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: go
 go:
-  - 1.5
-  - 1.6
   - 1.7
   - 1.8
   - 1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
   - 1.9
   - "1.10"
   - 1.11
+  - 1.12
   - tip
 before_install:
   - go get github.com/ugorji/go/codec


### PR DESCRIPTION
- remove 1.5 and 1.6
- add 1.12

The reason for removal is #27.