### PR TITLE
Use go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - "1.10"
   - 1.11
   - 1.12
+  - 1.13
   - tip
 before_install:
   - go get github.com/ugorji/go/codec

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,14 @@ go:
   - 1.13
   - tip
 before_install:
-  - go get github.com/ugorji/go/codec
+  - |
+    if expr $TRAVIS_GO_VERSION : 1\.11 > /dev/null; then
+      echo "Remove go.sum in order to avoid checksum mismatch go 1.11. Go changed how to calculate checksum."
+      rm go.sum go.mod
+    fi
 
 script:
- - go test -v ./...
-  - true
+  - go test -v ./...
+
+env:
+  - GO111MODULE=on

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/treasure-data/td-client-go
+
+go 1.13
+
+require github.com/ugorji/go/codec v1.1.7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
+github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
+github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=


### PR DESCRIPTION
Go introduced its package management system since 1.11.
ref: https://blog.golang.org/using-go-modules

Using this helps not only `td-client-go` developers but `td-client-go` users because our dependency on `github.com/ugorji/go/codec` is fixed.