### PR TITLE
Use HTTPS to default

### DIFF
--- a/td_client.go
+++ b/td_client.go
@@ -117,7 +117,6 @@ type Settings struct {
 	ConnectionTimeout time.Duration     // (Optional) Connection timeout
 	ReadTimeout       time.Duration     // (Optional) Read timeout.
 	SendTimeout       time.Duration     // (Optional) Send timeout.
-	Ssl               bool              // (Optional) Whether to use the secure connection.
 	RootCAs           *x509.CertPool    // (Optional) Specify the CA certificates.
 	Port              int               // (Optional) Port number.
 	Proxy             interface{}       // (Optional) HTTP proxy to use.
@@ -703,15 +702,10 @@ func NewTDClient(settings Settings) (*TDClient, error) {
 	if settings.UserAgent != "" {
 		userAgent += "; " + settings.UserAgent
 	}
-	if !settings.Ssl {
-		docUrl := "https://tddocs.atlassian.net/wiki/spaces/PD/pages/476545373/August+2020+Release+Note#Sunsetting-HTTP-Support"
-		fmt.Println("Warn: This request uses HTTPS endpoints even if `Ssl` option is not set.\n See: ", docUrl)
-	}
 	return &TDClient{
 		apiKey:            settings.ApiKey,
 		userAgent:         userAgent,
 		router:            router,
-		ssl:               settings.Ssl,
 		rootCAs:           settings.RootCAs,
 		port:              settings.Port,
 		connectionTimeout: settings.ConnectionTimeout,

--- a/td_client.go
+++ b/td_client.go
@@ -703,6 +703,10 @@ func NewTDClient(settings Settings) (*TDClient, error) {
 	if settings.UserAgent != "" {
 		userAgent += "; " + settings.UserAgent
 	}
+	if !settings.Ssl {
+		docUrl := "https://tddocs.atlassian.net/wiki/spaces/PD/pages/476545373/August+2020+Release+Note#Sunsetting-HTTP-Support"
+		fmt.Println("Warn: This request uses HTTPS endpoints even if `Ssl` option is not set.\n See: ", docUrl)
+	}
 	return &TDClient{
 		apiKey:            settings.ApiKey,
 		userAgent:         userAgent,

--- a/td_client.go
+++ b/td_client.go
@@ -110,6 +110,9 @@ type EndpointRouter interface {
 // Proxy can take three kinds of values: *url.URL (parsed URL), func(*http.Request)(*url.URL, error), string (URL) or nil (the direct connection to the endpoint is possible).
 //
 // Transport allows you to take more control over the communication.
+//
+// `Ssl` option was removed from client options.
+// td-client-go no longer support `Ssl` option since Treasure Data permitts only HTTP access after September 1, 2020.
 type Settings struct {
 	ApiKey            string            // Treasure Data Account API key
 	UserAgent         string            // (Optional) Name that will appear as the User-Agent HTTP header

--- a/td_client.go
+++ b/td_client.go
@@ -112,7 +112,7 @@ type EndpointRouter interface {
 // Transport allows you to take more control over the communication.
 //
 // `Ssl` option was removed from client options.
-// td-client-go no longer support `Ssl` option since Treasure Data permitts only HTTP access after September 1, 2020.
+// td-client-go no longer support `Ssl` option since Treasure Data permits only HTTPS access after September 1, 2020.
 type Settings struct {
 	ApiKey            string            // Treasure Data Account API key
 	UserAgent         string            // (Optional) Name that will appear as the User-Agent HTTP header

--- a/td_client.go
+++ b/td_client.go
@@ -230,10 +230,7 @@ func EmbeddedJSON(expectedTypeProto interface{}) ConverterFunc {
 
 func (client *TDClient) buildUrl(requestUri string, params url.Values) *url.URL {
 	endpoint := client.router.Route(requestUri)
-	scheme := "http"
-	if client.ssl {
-		scheme = "https"
-	}
+	scheme := "https"
 	host := endpoint
 	if client.port != 0 {
 		host = host + ":" + strconv.Itoa(client.port)


### PR DESCRIPTION
See: https://github.com/treasure-data/td-client-go/issues/31

Treasure Data API no longer supports HTTP by **August 31, 2020**
https://tddocs.atlassian.net/wiki/spaces/PD/pages/476545373/August+2020+Release+Note#Sunsetting-HTTP-Support

Thus, I changed to use HTTPS schema as default and add a message unless `Ssl: true`.
However, I would like to listen to your opinion about the message because I feel the message must be excessive.

e.g.)

```go
// main.go
package main

import (
	"fmt"
	td_client "github.com/treasure-data/td-client-go"
	"os"
)

func main() {
	apiKey := os.Getenv("TD_APIKEY")
	client, err := td_client.NewTDClient(td_client.Settings{
		ApiKey: apiKey,
	})
	if err != nil {
		fmt.Println(err.Error())
		return
	}
	status, err := client.ServerStatus()
	if err != nil {
		fmt.Println(err.Error())
		return
	}
	fmt.Printf("status: %s\n", status.Status)

	jobId := "817503734" // for sample job id
	jobDesc, err := client.ShowJob(jobId)
	if err != nil {
		fmt.Println(err.Error())
		return
	}
	fmt.Printf("query:%s\n", jobDesc.Query)
	fmt.Printf("startAt:%s\n", jobDesc.StartAt.String())
	fmt.Printf("endAt:%s\n", jobDesc.EndAt.String())
}
```

That code return:

```
% go run main.go
Warn: This request uses HTTPS endpoints even if `Ssl` option is not set.
 See:  https://tddocs.atlassian.net/wiki/spaces/PD/pages/476545373/August+2020+Release+Note#Sunsetting-HTTP-Support
status: ok
query:select 'treasure data'
startAt:2020-08-20 07:03:32 +0000 UTC
endAt:2020-08-20 07:03:32 +0000 UTC
```