### PR TITLE
CI uses Go 1.13 to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 sudo: false
 language: go
 go:
-  - 1.7
-  - 1.8
-  - 1.9
-  - "1.10"
-  - 1.11
   - 1.12
+  - 1.13
+  - 1.14
+  - 1.15
   - tip
 before_install:
   - go get github.com/ugorji/go/codec


### PR DESCRIPTION
I add Go versions (1.13, 1.14 and 1.15) to `.travis.yml` to test with these versions. And I cut 1.7 to 1.11 because it would be too old, which versions were released before 2018.

> Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including critical security problems, in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).

Golang has supported versions latest 2 major versions. Namely, in the current, Go 1.15 and 1.14 are supported. 
https://golang.org/doc/devel/release.html

However, what we follow the style would be overdoing. So I remain Go 1.12 which was released in February 2019.