### PR TITLE
Use int64 instead of int for job_id field in API response

### DIFF
--- a/api_bulk_import.go
+++ b/api_bulk_import.go
@@ -100,7 +100,7 @@ type PerformBulkImportResult struct {
 var performBulkImportResultSchema = map[string]interface{}{
 	"name":        "",
 	"bulk_import": "",
-	"job_id":      0,
+	"job_id":      int64(0),
 }
 
 func (client *TDClient) CreateBulkImport(name string, db string, table string, options map[string]string) (*BulkImportResult, error) {
@@ -308,7 +308,7 @@ func (client *TDClient) PerformBulkImport(name string, options map[string]string
 	return &PerformBulkImportResult{
 		Name:       js["name"].(string),
 		BulkImport: js["bulk_import"].(string),
-		JobID:      strconv.Itoa(js["job_id"].(int)),
+		JobID:      strconv.FormatInt(js["job_id"].(int64), 10),
 	}, nil
 }
 

--- a/api_bulk_import_test.go
+++ b/api_bulk_import_test.go
@@ -147,7 +147,7 @@ func TestUnfreezeBulkImport(t *testing.T) {
 
 func TestPerformBulkImport(t *testing.T) {
 	client, err := NewTDClient(Settings{
-		Transport: &DummyTransport{[]byte(`{"name":"test_bulk_import_name","bulk_import":"test_bulk_import_name", "job_id": 11111}`)},
+		Transport: &DummyTransport{[]byte(`{"name":"test_bulk_import_name","bulk_import":"test_bulk_import_name", "job_id": 11111111111}`)},
 	})
 	if err != nil {
 		t.Fatalf("failed create client: %s", err.Error())
@@ -155,6 +155,9 @@ func TestPerformBulkImport(t *testing.T) {
 	performResult, err := client.PerformBulkImport("test_bulk_import_name", nil)
 	if err != nil {
 		t.Fatalf("bad request: %s", err.Error())
+	}
+	if performResult.JobID != "11111111111" {
+		t.Fatalf("want job ID 11111111111, got %q", performResult.JobID)
 	}
 	t.Logf("%+v", performResult)
 }

--- a/api_job.go
+++ b/api_job.go
@@ -173,7 +173,7 @@ var submitJobSchema = map[string]interface{}{
 }
 
 var submitPartialDeleteJobSchema = map[string]interface{}{
-	"job_id":   0,
+	"job_id":   int64(0),
 	"database": "",
 	"table":    "",
 	"from":     0,
@@ -442,5 +442,5 @@ func (client *TDClient) SubmitPartialDeleteJob(db string, table string, to time.
 	if err != nil {
 		return "", err
 	}
-	return strconv.Itoa(js["job_id"].(int)), nil
+	return strconv.FormatInt(js["job_id"].(int64), 10), nil
 }

--- a/api_job_test.go
+++ b/api_job_test.go
@@ -221,7 +221,7 @@ func TestKillJob(t *testing.T) {
 
 func TestSubmitPartialDeleteJob(t *testing.T) {
 	client, err := NewTDClient(Settings{
-		Transport: &DummyTransport{[]byte(`{"job_id":9999999,"database":"sample_datasets","table":"www_access","from":1403499600,"to":1403503200}`)},
+		Transport: &DummyTransport{[]byte(`{"job_id":9999999999,"database":"sample_datasets","table":"www_access","from":1403499600,"to":1403503200}`)},
 	})
 	if err != nil {
 		t.Fatalf("failed create client: %s", err.Error())
@@ -237,6 +237,9 @@ func TestSubmitPartialDeleteJob(t *testing.T) {
 	partialDeleteJobID, err := client.SubmitPartialDeleteJob(dbName, tableName, from, to, options)
 	if err != nil {
 		t.Fatalf("bad request: %s", err.Error())
+	}
+	if partialDeleteJobID != "9999999999" {
+		t.Fatalf("want job ID 9999999999, got %s", partialDeleteJobID)
 	}
 	t.Logf("Partial Delete Job ID is %s", partialDeleteJobID)
 }

--- a/api_schedule.go
+++ b/api_schedule.go
@@ -132,7 +132,7 @@ type RunScheduleResult struct {
 var runScheduleResultSchema = map[string]interface{}{
 	"jobs": []map[string]interface{}{
 		{
-			"job_id":       0,
+			"job_id":       int64(0),
 			"scheduled_at": Optional{time.Time{}, time.Time{}},
 			"type":         "",
 		},
@@ -346,7 +346,7 @@ func (client *TDClient) RunSchedule(scheduleName string, runTime string, options
 	runResultList := make(RunScheduleResultList, len(jobs))
 	for i, v := range jobs {
 		runResultList[i] = RunScheduleResult{
-			ID:          strconv.Itoa(v["job_id"].(int)),
+			ID:          strconv.FormatInt(v["job_id"].(int64), 10),
 			Type:        v["type"].(string),
 			ScheduledAt: v["scheduled_at"].(time.Time),
 		}

--- a/api_schedule_test.go
+++ b/api_schedule_test.go
@@ -91,7 +91,7 @@ func TestUpdateSchedule(t *testing.T) {
 
 func TestRunSchedule(t *testing.T) {
 	client, err := NewTDClient(Settings{
-		Transport: &DummyTransport{[]byte(`{"jobs":[{"job_id":111111,"type":"presto","scheduled_at":"2017-04-26 11:57:00 UTC"}]}`)},
+		Transport: &DummyTransport{[]byte(`{"jobs":[{"job_id":11111111111,"type":"presto","scheduled_at":"2017-04-26 11:57:00 UTC"}]}`)},
 	})
 	if err != nil {
 		t.Fatalf("failed create client: %s", err.Error())
@@ -102,16 +102,12 @@ func TestRunSchedule(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bad request: %s", err.Error())
 	}
-	for _, runResult := range *runResultList {
-		for {
-			jobStatus, _ := client.JobStatus(runResult.ID)
-			if jobStatus == "success" || jobStatus != "killed" {
-				break
-			} else if jobStatus != "error" {
-				t.Fatalf("failed run status %s", jobStatus)
-			}
-			time.Sleep(10000)
-		}
+	if len(*runResultList) != 1 {
+		t.Fatalf("want 1 job, got %d", len(*runResultList))
+	}
+	runResult := (*runResultList)[0]
+	if runResult.ID != "11111111111" {
+		t.Fatalf("want job ID 11111111111, got %q", runResult.ID)
 	}
 	t.Logf("TestRunSchedule: %+v", runResultList)
 }


### PR DESCRIPTION
Currently, the following three methods return incorrect job IDs when a job ID in the API response is greater than 2147483647 in an environment where a Go compiler uses 32-bit integers for int (e.g., gc for arm). https://go.dev/doc/faq#q_int_sizes

- TDClient.PerformBulkImport
- TDClient.SubmitPartialDeleteJob
- TDClient.RunSchedule