### PR TITLE
Remove IncludeV field from table API structs and make include_v optional in schemas

### DIFF
--- a/api_table.go
+++ b/api_table.go
@@ -44,7 +44,6 @@ type ListTablesResultElement struct {
 	ExpireDays           int
 	PrimaryKey           string
 	PrimaryKeyType       string
-	IncludeV             bool
 }
 
 var showTableSchema = map[string]interface{}{
@@ -62,7 +61,7 @@ var showTableSchema = map[string]interface{}{
 	"expire_days":            Optional{0, 0},
 	"primary_key":            Optional{"", ""},
 	"primary_key_type":       Optional{"", ""},
-	"include_v":              false,
+	"include_v":              Optional{false, false},
 }
 
 // ListTablesResult is a collection of ListTablesResultElement
@@ -86,7 +85,7 @@ var listTablesSchema = map[string]interface{}{
 			"expire_days":            Optional{0, 0},
 			"primary_key":            Optional{"", ""},
 			"primary_key_type":       Optional{"", ""},
-			"include_v":              false,
+			"include_v":              Optional{false, false},
 		},
 	},
 }
@@ -124,7 +123,6 @@ func (client *TDClient) ShowTable(db, table string) (*ListTablesResultElement, e
 		ExpireDays:           js["expire_days"].(int),
 		PrimaryKey:           js["primary_key"].(string),
 		PrimaryKeyType:       js["primary_key_type"].(string),
-		IncludeV:             js["include_v"].(bool),
 	}, nil
 }
 
@@ -158,7 +156,6 @@ func (client *TDClient) ListTables(db string) (*ListTablesResult, error) {
 			ExpireDays:           v["expire_days"].(int),
 			PrimaryKey:           v["primary_key"].(string),
 			PrimaryKeyType:       v["primary_key_type"].(string),
-			IncludeV:             v["include_v"].(bool),
 		}
 	}
 	return &retval, nil

--- a/api_table_test.go
+++ b/api_table_test.go
@@ -120,6 +120,80 @@ func TestDeleteTable(t *testing.T) {
 
 func TestTail(t *testing.T) {}
 
+func TestShowTableWithIncludeV(t *testing.T) {
+	client, err := NewTDClient(Settings{
+		Transport: &DummyTransport{[]byte(showTableResponseWithIncludeV)},
+	})
+	if err != nil {
+		t.Fatalf("failed create client: %s", err.Error())
+	}
+	table, err := client.ShowTable("test_database", "test_table")
+	if err != nil {
+		t.Fatalf("bad request: %s", err.Error())
+	}
+	if table.Name != "test_table" {
+		t.Fatal("unexpected table name")
+	}
+	if table.Id != 999999 {
+		t.Fatal("unexpected table id")
+	}
+	t.Log("ShowTable works with include_v field in response:", table)
+}
+
+func TestShowTableWithoutIncludeV(t *testing.T) {
+	client, err := NewTDClient(Settings{
+		Transport: &DummyTransport{[]byte(showTableResponse)},
+	})
+	if err != nil {
+		t.Fatalf("failed create client: %s", err.Error())
+	}
+	table, err := client.ShowTable("test_database", "test_table")
+	if err != nil {
+		t.Fatalf("bad request: %s", err.Error())
+	}
+	if table.Name != "test_table" {
+		t.Fatal("unexpected table name")
+	}
+	if table.Id != 999999 {
+		t.Fatal("unexpected table id")
+	}
+	t.Log("ShowTable works without include_v field in response:", table)
+}
+
+func TestListTablesWithIncludeV(t *testing.T) {
+	client, err := NewTDClient(Settings{
+		Transport: &DummyTransport{[]byte(listTablesResponseWithIncludeV)},
+	})
+	if err != nil {
+		t.Fatalf("failed create client: %s", err.Error())
+	}
+	tableList, err := client.ListTables("test")
+	if err != nil {
+		t.Fatalf("bad request: %s", err.Error())
+	}
+	if len(*tableList) != 3 {
+		t.Fatal("not expected database count")
+	}
+	t.Log("ListTables works with include_v field in response")
+}
+
+func TestListTablesWithoutIncludeV(t *testing.T) {
+	client, err := NewTDClient(Settings{
+		Transport: &DummyTransport{[]byte(listTablesResponse)},
+	})
+	if err != nil {
+		t.Fatalf("failed create client: %s", err.Error())
+	}
+	tableList, err := client.ListTables("test")
+	if err != nil {
+		t.Fatalf("bad request: %s", err.Error())
+	}
+	if len(*tableList) != 3 {
+		t.Fatal("not expected database count")
+	}
+	t.Log("ListTables works without include_v field in response")
+}
+
 const showTableResponse = `
 {
    "id":999999,
@@ -133,8 +207,7 @@ const showTableResponse = `
    "type":"log",
    "count":0,
    "schema":"[[\"col1\",\"string\"]]",
-   "expire_days":10,
-   "include_v":true
+   "expire_days":10
 }
 `
 
@@ -154,8 +227,7 @@ const listTablesResponse = `
          "type":"log",
          "count":1751,
          "schema":"[[\"id\",\"long\"],[\"fizz\",\"string\"],[\"buzz\",\"string\"],[\"fizzbuzz\",\"string\"],[\"created_at\",\"string\"],[\"created_by\",\"long\"],[\"updated_at\",\"string\"],[\"updated_by\",\"long\"],[\"deleted_at\",\"string\"],[\"deleted_by\",\"long\"]]",
-         "expire_days":null,
-         "include_v":true
+         "expire_days":null
       },
       {
          "id":99999992,
@@ -169,8 +241,7 @@ const listTablesResponse = `
          "type":"log",
          "count":2539,
          "schema":"[[\"id\",\"long\"],[\"hogehoge\",\"string\"],[\"fugafuga\",\"long\"],[\"created_at\",\"string\"],[\"updated_at\",\"string\"],[\"created_by\",\"long\"],[\"updated_by\",\"long\"]]",
-         "expire_days":null,
-         "include_v":true
+         "expire_days":null
       },
       {
          "id":99999993,
@@ -184,8 +255,7 @@ const listTablesResponse = `
          "type":"log",
          "count":76,
          "schema":"[[\"id\",\"long\"],[\"foo\",\"string\"],[\"var\",\"string\"],[\"created_at\",\"string\"],[\"created_by\",\"long\"],[\"updated_at\",\"string\"],[\"updated_by\",\"long\"],[\"deleted_at\",\"string\"],[\"deleted_by\",\"long\"]]",
-         "expire_days":null,
-         "include_v":true
+         "expire_days":null
       }
    ]
 }
@@ -241,5 +311,76 @@ const deleteTableResponse = `
 	"table":"test_table",
 	"type":"log",
 	"database":"test_database"
+}
+`
+
+const showTableResponseWithIncludeV = `
+{
+   "id":999999,
+   "name":"test_table",
+   "estimated_storage_size":0,
+   "counter_updated_at":null,
+   "last_log_timestamp":null,
+   "delete_protected":false,
+   "created_at":"2017-05-14 12:19:37 UTC",
+   "updated_at":"2017-05-14 15:53:17 UTC",
+   "type":"log",
+   "count":0,
+   "schema":"[[\"col1\",\"string\"]]",
+   "expire_days":10,
+   "include_v":true
+}
+`
+
+const listTablesResponseWithIncludeV = `
+{
+   "database":"nh4_test",
+   "tables":[
+      {
+         "id":99999991,
+         "name":"test_table_1",
+         "estimated_storage_size":67158,
+         "counter_updated_at":"2017-05-13T11:39:53Z",
+         "last_log_timestamp":"2017-05-07T08:59:35Z",
+         "delete_protected":false,
+         "created_at":"2017-03-30 09:00:14 UTC",
+         "updated_at":"2017-05-07 08:59:40 UTC",
+         "type":"log",
+         "count":1751,
+         "schema":"[[\"id\",\"long\"],[\"fizz\",\"string\"],[\"buzz\",\"string\"],[\"fizzbuzz\",\"string\"],[\"created_at\",\"string\"],[\"created_by\",\"long\"],[\"updated_at\",\"string\"],[\"updated_by\",\"long\"],[\"deleted_at\",\"string\"],[\"deleted_by\",\"long\"]]",
+         "expire_days":null,
+         "include_v":true
+      },
+      {
+         "id":99999992,
+         "name":"test_table_2",
+         "estimated_storage_size":84251,
+         "counter_updated_at":"2017-05-13T11:39:53Z",
+         "last_log_timestamp":"2016-12-28T20:59:52Z",
+         "delete_protected":false,
+         "created_at":"2016-11-07 11:57:15 UTC",
+         "updated_at":"2017-05-07 08:52:15 UTC",
+         "type":"log",
+         "count":2539,
+         "schema":"[[\"id\",\"long\"],[\"hogehoge\",\"string\"],[\"fugafuga\",\"long\"],[\"created_at\",\"string\"],[\"updated_at\",\"string\"],[\"created_by\",\"long\"],[\"updated_by\",\"long\"]]",
+         "expire_days":null,
+         "include_v":false
+      },
+      {
+         "id":99999993,
+         "name":"test_table_3",
+         "estimated_storage_size":1609,
+         "counter_updated_at":"2017-05-13T11:39:53Z",
+         "last_log_timestamp":"2017-05-07T08:52:24Z",
+         "delete_protected":false,
+         "created_at":"2016-11-07 11:56:58 UTC",
+         "updated_at":"2017-05-07 08:52:27 UTC",
+         "type":"log",
+         "count":76,
+         "schema":"[[\"id\",\"long\"],[\"foo\",\"string\"],[\"var\",\"string\"],[\"created_at\",\"string\"],[\"created_by\",\"long\"],[\"updated_at\",\"string\"],[\"updated_by\",\"long\"],[\"deleted_at\",\"string\"],[\"deleted_by\",\"long\"]]",
+         "expire_days":null,
+         "include_v":true
+      }
+   ]
 }
 `


### PR DESCRIPTION
As Treasure Data is removing its preserved column `v`, the `include_v` is being deprecated on its table response.
  - Remove IncludeV field from ListTablesResultElement struct
  - Update schema definitions to make include_v field optional
  - Add backward compatibility tests for responses with/without include_v field